### PR TITLE
Needed changes to boot Big sur beta

### DIFF
--- a/EFIOC/OC/config.plist
+++ b/EFIOC/OC/config.plist
@@ -1218,7 +1218,7 @@
 			<key>PasswordSalt</key>
 			<data></data>
 			<key>SecureBootModel</key>
-			<string>Default</string>
+			<string>Disabled</string>
 			<key>ScanPolicy</key>
 			<integer>0</integer>
 			<key>Vault</key>
@@ -1300,7 +1300,7 @@
 				<key>boot-args</key>
 				<string>darkwake=0 gfxrst=1 igfxonln=1 igfxonlnfbs=0x010203</string>
 				<key>csr-active-config</key>
-				<data>ZwAAAA==</data>
+				<data>AAAAAA==</data>
 				<key>run-efi-updater</key>
 				<string>No</string>
 			</dict>


### PR DESCRIPTION
Set SecureBootModel to disabled and enable full SIP. This fixes https://github.com/johnnync13/Xiaomi-Mi-Air/issues/198